### PR TITLE
Remove precise as a supported series

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,4 +10,3 @@ series:
   - bionic
   - artful
   - trusty
-  - precise

--- a/tests/010_basic_precise
+++ b/tests/010_basic_precise
@@ -1,7 +1,0 @@
-#!/usr/bin/python
-"""Amulet tests on a basic ubuntu charm deployment on precise."""
-
-from basic_deployment import ubuntu_basic_deployment
-
-if __name__ == '__main__':
-    ubuntu_basic_deployment(series='precise')


### PR DESCRIPTION
Precise does not support reactive charms.

Closes: #3