### PR TITLE
Fix deploy error due to new pip / old setuptools conflict

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,6 @@
 includes:
  - 'layer:basic'
 repo: https://github.com/juju-solutions/charm-ubuntu
+options:
+  basic:
+    include_system_packages: true


### PR DESCRIPTION
Newer versions of pip (>=19.0) don't work with older versions of setuptools (<40) due to an attribute error.  If `include_system_packages` is `false` (now the default), this is not an issue because of the newer setuptools that gets installed into the venv. However, when it's `true`, which is required for some charms, the install fails because pip somehow prefers the older system-installed setuptools over the newer one in the venv. Pinning pip avoids the problem until we can find a better solution.

See:
  * https://discourse.jujucharms.com/t/wheel-building-fails-during-charm-deployment/1947
  * https://github.com/pypa/pip/issues/6164