### PR TITLE
yaml lint fix (valid default)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   hostname:
     type: string
-    default: 
+    default: ""
     description: Override hostname of machine, when empty uses default machine hostname
 


### PR DESCRIPTION
Charm tool complained
proof: I: config.yaml: option hostname has no default value