### PR TITLE
Update integration tests with pytest-operator

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,31 +3,28 @@ from pathlib import Path
 
 import pytest
 import yaml
-from pytest_operator import OperatorTest
 
 
 log = logging.getLogger(__name__)
+meta = yaml.safe_load(Path("metadata.yaml").read_text())
 
 
-class UbuntuIntegrationTest(OperatorTest):
-    meta = yaml.safe_load(Path("metadata.yaml").read_text())
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test):
+    charm = await ops_test.build_charm(".")
+    for series in meta["series"]:
+        await ops_test.model.deploy(charm, application_name=series, series=series)
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
 
-    @pytest.mark.order("first")
-    @pytest.mark.abort_on_fail
-    async def test_build_and_deploy(self):
-        charm = await self.build_charm(".")
-        for series in self.meta["series"]:
-            await self.model.deploy(charm, application_name=series, series=series)
-        await self.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
 
-    async def test_app_versions(self):
-        """ Validate that the app versions are correct. """
-        expected = {
-            "focal": "20.04",
-            "bionic": "18.04",
-            "xenial": "16.04",
-            "groovy": "20.10",
-        }
-        for series in self.meta["series"]:
-            app = self.model.applications[series]
-            assert app.workload_version == expected[series]
+async def test_app_versions(ops_test):
+    """ Validate that the app versions are correct. """
+    expected = {
+        "focal": "20.04",
+        "bionic": "18.04",
+        "xenial": "16.04",
+        "groovy": "20.10",
+    }
+    for series in meta["series"]:
+        app = ops_test.model.applications[series]
+        assert app.workload_version == expected[series]

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,8 @@ commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s --disabl
 
 [testenv:integration]
 deps =
-    # Until libjuju 2.8.6+ is released
-    https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
     pytest-operator
-    pytest-order
     ipdb
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s --disable-warnings {posargs} {toxinidir}/tests/integration
 


### PR DESCRIPTION
The usage of pytest-operator was updated to drop support for unittest.TestCase based test and this brings the integration tests in this charm in line with those changes.