### PR TITLE
Add storage

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,3 +10,15 @@ series:
   - bionic
   - xenial
   - groovy
+storage:
+  block:
+    type: block
+    description: block device
+    minimum-size: 100M
+    multiple:
+      range: 0-
+  files:
+    type: filesystem
+    description: Mounted filesystem
+    minimum-size: 100M
+    location: /srv/data


### PR DESCRIPTION
Add optional storage support to allow testing and development with block
devices and extra filesystems.