### PR TITLE
Add a charmcraft.yaml, add support for jammy and remove EOL groovy, hirsuite series

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,16 @@
+type: charm
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "16.04"
+    - name: "ubuntu"
+      channel: "18.04"
+    - name: "ubuntu"
+      channel: "20.04"
+    - name: "ubuntu"
+      channel: "21.04"
+    - name: "ubuntu"
+      channel: "22.04"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,10 +11,4 @@ bases:
     - name: "ubuntu"
       channel: "20.04"
     - name: "ubuntu"
-      channel: "21.04"
-    - name: "ubuntu"
       channel: "22.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,3 +14,7 @@ bases:
       channel: "21.04"
     - name: "ubuntu"
       channel: "22.04"
+parts:
+  charm:
+    build-packages:
+      - git

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,3 +10,4 @@ series:
   - bionic
   - xenial
   - hirsute
+  - jammy

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,5 +9,4 @@ series:
   - focal
   - bionic
   - xenial
-  - groovy
   - hirsute

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,5 +9,4 @@ series:
   - focal
   - bionic
   - xenial
-  - hirsute
   - jammy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-# ops>=1.0,<2.0
-# Needed due to https://github.com/canonical/operator/issues/517 not yet being
-# included in a released version.
-git+https://github.com/canonical/operator/#egg=ops
+ops>=1.0,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-ops>=1.0,<2.0
+# ops>=1.0,<2.0
+# Needed due to https://github.com/canonical/operator/issues/517 not yet being
+# included in a released version.
+git+https://github.com/canonical/operator/#egg=ops

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,8 +23,7 @@ async def test_app_versions(ops_test):
         "focal": "20.04",
         "bionic": "18.04",
         "xenial": "16.04",
-        "groovy": "20.10",
-        "hirsute": "21.04",
+        "jammy": "22.04",
     }
     for series in meta["series"]:
         app = ops_test.model.applications[series]


### PR DESCRIPTION
Charms now need a charmcraft.yaml file to define what series to build on and for. 

Also remove `groovy`, which is EOL since July 2021.