### PR TITLE
use model-config in integration test (needed for pre-GA jammy)

### DIFF
--- a/tests/data/model-config.yaml
+++ b/tests/data/model-config.yaml
@@ -1,0 +1,2 @@
+---
+image-stream: daily

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     pytest
     pytest-operator
     ipdb
-commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s --disable-warnings {posargs} {toxinidir}/tests/integration
+commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s --disable-warnings --model-config tests/data/model-config.yaml {posargs} {toxinidir}/tests/integration
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Follow-on to #41

Jammy images aren't released in juju streams yet.  We'll need to use the 'daily' streams when testing jammy.  Luckily, pytest-operator lets us do this with `--model-config $yaml`.