### PR TITLE
Optional Filesystem Storage

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,5 +19,7 @@ storage:
   files:
     type: filesystem
     description: Mounted filesystem
-    minimum-size: 100M
     location: /srv/data
+    minimum-size: 100M
+    multiple:
+      range: 0-


### PR DESCRIPTION
make the filesystem storage optional by allowing the number of filesystem storage types to be 0

by default, a deployment of this charm no longer requires juju to make storage

```bash
> juju storage; juju status

No storage to display.
Model                              Controller   Cloud/Region   Version  SLA          Timestamp
my_model                           addyess-aws  aws/us-east-2  2.9.42   unsupported  15:33:02-05:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      2  ubuntu             0  no 

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/1*  active    idle   1        18.116.69.179     
ubuntu/2   active    idle   1/lxd/0  252.0.210.81     

Machine  State    Address        Inst id              Series  AZ          Message
1        started  18.116.69.179  i-0bb13f034ffe175b6  focal   us-east-2a  running
1/lxd/0  started  252.0.210.81   juju-fc5934-1-lxd-0  focal   us-east-2a  Container started
```