### PR TITLE
Limit the mounted filesystem storages to 1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,4 +22,4 @@ storage:
     location: /srv/data
     minimum-size: 100M
     multiple:
-      range: 0-
+      range: 0-1


### PR DESCRIPTION
Existing `latest/stable` deployments of the `ubuntu` charm will have a single mandatory file-system mounted storage.  
Fresh deployments of the `ubuntu` charm shouldn't require this mandatory file-system storage

In order to permit upgrades of those units, [juju will check](https://github.com/juju/juju/blob/90fe0d663cba19bfb98da94f2f1afed4c795664e/state/application.go#L1167) that the next charm's metadata still has a `CountMax == 1`  -- which it will

Yet in order to permit fresh install of this charm, juju will not longer require the storage to be created